### PR TITLE
[QAE-486] Closed Loop Boluss Test support

### DIFF
--- a/Sources/LoopUITestingKit/Helpers/Utils.swift
+++ b/Sources/LoopUITestingKit/Helpers/Utils.swift
@@ -190,4 +190,29 @@ extension XCUIApplication {
             maxAttempts -= 1
         }
     }
+    
+    public func waitForExpectedState(
+        expectedState: @escaping () -> Bool,
+        passAfterSeconds: Int = 0,
+        failAfterSeconds: Int = 5,
+        testInfo: XCTestCase
+    ) -> Bool {
+        let expectation = XCTestExpectation(description: "End timer if \(expectedState()) is true")
+        var counter = 0
+        var actualMatch: Bool = false
+        var timer: Timer?
+        
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
+            counter += 1
+            guard expectedState() else { return }
+            
+            timer?.invalidate()
+            actualMatch = counter >= passAfterSeconds
+            expectation.fulfill()
+        }
+        testInfo.executionTimeAllowance = TimeInterval(failAfterSeconds + 1)
+        _ = XCTWaiter.wait(for: [expectation], timeout: TimeInterval(failAfterSeconds))
+        timer?.invalidate()
+        return actualMatch
+    }
 }

--- a/Sources/LoopUITestingKit/Screens/BolusScreen.swift
+++ b/Sources/LoopUITestingKit/Screens/BolusScreen.swift
@@ -13,6 +13,7 @@ public final class BolusScreen: BaseScreen {
 
     private var bolusTitleText: XCUIElement { app.navigationBars.staticTexts["Bolus"] }
     private var currentGlucoseEntryTextField: XCUIElement { app.textFields["textField_CurrentGlucose"] }
+    private var fingerstickGlucoseTextField: XCUIElement { app.textFields["textField_FingerstickGlucose"] }
     private var bolusEntryTextField: XCUIElement { app.textFields["textField_Bolus"] }
     private var carbohydratesTextField: XCUIElement { app.textFields["textField_Carbohydrates"] }
     private var recommendedBolusStaticText: XCUIElement { app.staticTexts["staticText_RecommendedBolus"] }
@@ -20,6 +21,7 @@ public final class BolusScreen: BaseScreen {
     private var simpleBolusCalculatorTitle: XCUIElement { app.navigationBars.staticTexts["Simple Bolus Calculator"] }
     private var bolusActionButton: XCUIElement { app.buttons["button_bolusAction"] }
     private var activeCarbsText: XCUIElement { app.staticTexts["text_ActiveCarbs"] }
+    private var enterFingerstickGlucoseButton: XCUIElement { app.buttons["button_EnterFingerstickGlucose"] }
     
     private var keyboardDoneButton: XCUIElement { app.toolbars.firstMatch.buttons["Done"].firstMatch }
     
@@ -28,11 +30,14 @@ public final class BolusScreen: BaseScreen {
     public func tapBolusActionButton() { bolusActionButton.safeForceTap() }
     public func tapCancelBolusButton() { bolusCancelButton.safeTap() }
     public func tapCurrentGlucoseTextField() { currentGlucoseEntryTextField.safeTap() }
+    public func tapFingerstickGlucoseTextField() { fingerstickGlucoseTextField.safeTap() }
     public func tapCarbohydratesTextField() { carbohydratesTextField.safeTap() }
     public func tapBolusTextField() { bolusEntryTextField.safeTap() }
     public func tapKeyboardDoneButton() { keyboardDoneButton.safeTap() }
+    public func tapEnterFingerstickGlucoseButton() { enterFingerstickGlucoseButton.safeTap() }
     
     public var getCurrentGlucoseTextFieldValue: String { currentGlucoseEntryTextField.getValueSafe() }
+    public var getFingerstickGlucoseTextFieldValue: String { fingerstickGlucoseTextField.getValueSafe() }
     public var getCarbohydratesTextFieldValue: String { carbohydratesTextField.getValueSafe() }
     public var getRecommendedBolusStaticTextValue: String { recommendedBolusStaticText.getLableSafe() }
     public var getBolusTextFieldValue: String { bolusEntryTextField.getValueSafe() }
@@ -40,15 +45,18 @@ public final class BolusScreen: BaseScreen {
     public var getActiveCarbsText: String { activeCarbsText.getLableSafe() }
     
     public func clearCurrentGlucoseTextFieldValue() { currentGlucoseEntryTextField.clearTextField() }
+    public func clearFingerstickGlucoseTextFieldValue() { fingerstickGlucoseTextField.clearTextField() }
     public func clearCarbohydratesTextFieldValue() { carbohydratesTextField.clearTextField() }
     public func clearBolusTextFieldValue() { bolusEntryTextField.clearTextField() }
     
     public func setCurrentGlucoseTextFieldValue(_ value: String) { currentGlucoseEntryTextField.typeText(value) }
+    public func setFingerstickGlucoseTextFieldValue(_ value: String ) { fingerstickGlucoseTextField.typeText(value) }
     public func setCarbohydratesTextFieldValue(_ value: String) { carbohydratesTextField.typeText(value) }
     public func setBolusTextFieldValue(_ value: String) { bolusEntryTextField.typeText(value) }
 
     // MARK: Verifications
     
     public var bolusTitleExists: Bool { bolusTitleText.safeExists }
+    public var fingerstickGlucoseTextFieldExists: Bool { fingerstickGlucoseTextField.safeExists }
     public var simpleBolusCalculatorTitleExists: Bool { simpleBolusCalculatorTitle.safeExists }
 }

--- a/Sources/LoopUITestingKit/Screens/CGMManagerScreen.swift
+++ b/Sources/LoopUITestingKit/Screens/CGMManagerScreen.swift
@@ -28,6 +28,7 @@ public final class CGMManagerScreen: BaseScreen {
     private var referenceDateCell: XCUIElement { app.cells["cell_ReferenceDate"] }
     private var measurementFrequencyCell: XCUIElement { app.cells["cell_MeasurementFrequency"] }
     private var glucoseNoiseCell: XCUIElement { app.cells["cell_GlucoseNoise"] }
+    private var signalLossCell: XCUIElement { app.cells["cell_SignalLoss"] }
     private var backfillGlucoseCell: XCUIElement { app.cells["cell_BackfillGlucose"].firstMatch }
     private var warningThresholdCell: XCUIElement { app.cells["cell_WarningThreshold"].firstMatch }
     private var criticalThresholdCell: XCUIElement {
@@ -62,6 +63,7 @@ public final class CGMManagerScreen: BaseScreen {
     public func tapSineCurveCell() { sineCurveCell.safeTap() }
     public func tapMeasurementFrequencyCell() { measurementFrequencyCell.safeTap() }
     public func tapGlucoseNoiseCell() { glucoseNoiseCell.safeTap() }
+    public func tapSignalLossCell() { signalLossCell.safeTap() }
     public func tapBackfillGlucoseCell() { backfillGlucoseCell.safeTap() }
     public func tapWarningThresholdCell() { warningThresholdCell.safeTap() }
     public func tapCriticalThresholdCell() { criticalThresholdCell.safeTap() }

--- a/Sources/LoopUITestingKit/Screens/HomeScreen.swift
+++ b/Sources/LoopUITestingKit/Screens/HomeScreen.swift
@@ -58,6 +58,7 @@ public final class HomeScreen: BaseScreen {
     }
     private var bolusProgressText: XCUIElement { app.staticTexts["text_BolusingProgress"] }
     private var tapToStopText: XCUIElement { app.staticTexts["text_TapToStop"] }
+    private var noRecentGlucoseText: XCUIElement { app.staticTexts["text_NoRecentGlucose"] }
     private var bolusCanceledText: XCUIElement { app.staticTexts["text_BolusCanceled"] }
     private var insulinSuspendedText: XCUIElement { app.staticTexts["text_InsulinSuspended"] }
     private var insulinTapToResumeText: XCUIElement { app.staticTexts["text_InsulinTapToResume"] }
@@ -75,7 +76,7 @@ public final class HomeScreen: BaseScreen {
     public var getBolusProgressText: String { bolusProgressText.getLableSafe() }
     public var getActiveCarbsValue: String {
         _ = navigateToActiveCarbsDetailsText.safeExists
-        return navigateToActiveCarbsDetailsText.identifier.components(separatedBy: "_")[2]
+        return navigateToActiveCarbsDetailsText.identifier.components(separatedBy: "_")[2].replacingOccurrences(of: "[^0-9]", with: "", options: .regularExpression)
     }
     public var getActiveInsulinXAxisCount: Int {
         _ = navigateToActiveInsulinDetailsText.safeExists
@@ -159,8 +160,9 @@ public final class HomeScreen: BaseScreen {
         if !isDisabled { NavigationBar(app: app).tapBackButton() }
         return isDisabled
     }
-    
     public func pumpPillDisplaysValue(value: String) {
         XCTAssertTrue(hudPumpPill.getValueSafe().contains(NSLocalizedString(value, comment: "")))
+    }
+    public func noRecentGlucoseTextExists(passAfter: Int, failAfter: Int, testInfo: XCTestCase) -> Bool { app.waitForExpectedState(expectedState: { self.noRecentGlucoseText.exists }, passAfterSeconds: passAfter, failAfterSeconds: failAfter, testInfo: testInfo)
     }
 }

--- a/Sources/LoopUITestingKit/Screens/PasscodeScreen.swift
+++ b/Sources/LoopUITestingKit/Screens/PasscodeScreen.swift
@@ -10,7 +10,7 @@ import XCTest
 public final class PasscodeScreen: BaseScreen {
     
     // MARK: Elements
-    
+
     private var passcodeEntry: XCUIElement { springBoard.secureTextFields["Passcode field"] }
 
     // MARK: Actions

--- a/Sources/LoopUITestingKit/Screens/TherapySettingsScreen.swift
+++ b/Sources/LoopUITestingKit/Screens/TherapySettingsScreen.swift
@@ -219,6 +219,7 @@ public final class TherapySettingsScreen: BaseScreen {
     public func tapRapidActingChildren() { rapidActingChildrenButton.safeTap() }
     public func tapGlucoseSafetyLimitText() { glucoseSafetyLimitText.safeTap() }
     public func tapBasalRatesText() { basalRatesText.safeTap() }
+    public func tapGlucoseSafetyLimitValueText() { glucoseSafetyLimitValueText.safeTap() }
     
     public func tapSaveSettingsButton() {
         app.swipeToElement(element: saveSettingsButton, swipeDirection: .up, swipeVelocity: .fast)
@@ -293,7 +294,8 @@ public final class TherapySettingsScreen: BaseScreen {
     public var workoutRangeAlertTitleTextExists: Bool { workoutRangeAlertTitleText.safeExists }
     public var carbRatiosAlertTitleTextExists: Bool { carbRatiosAlertTitleText.safeExists }
     public var insulinSensitivitiesAlertTitleTextExists: Bool { insulinSensitivitiesAlertTitleText.safeExists }
-        
+    public var glucoseSafetyLimitValueTextExists: Bool { glucoseSafetyLimitValueText.safeExists }
+    
     public var removeScheduleItemButtonExists: Bool {
         scheduleItemText.matching(NSPredicate(format: "label == '－'")).firstMatch.safeExists
     }


### PR DESCRIPTION
-SignalLoss cell
-NoRecentGlucose (temporary status bar)
-EnterFingerstickGlucose button
-FingerstickGlucose field
-GlucoseSafetyLimitValue (exist/tap for editing value)
-Created Passcode screen and migrated functionality from Bolus screen. Passcode is used for saving therapy Settings post onboarding.